### PR TITLE
Fix compatibility with tasty-hspec 1.1.7

### DIFF
--- a/monad-dijkstra.cabal
+++ b/monad-dijkstra.cabal
@@ -41,7 +41,7 @@ test-suite test-monad-dijkstra
         base >=4.7 && <5,
         hspec -any,
         tasty -any,
-        tasty-hspec >= 1.1.7,
+        tasty-hspec -any,
         monad-dijkstra -any
 
     if !impl(ghc >=8.0)

--- a/monad-dijkstra.cabal
+++ b/monad-dijkstra.cabal
@@ -39,8 +39,9 @@ test-suite test-monad-dijkstra
     ghc-options:      -Wall -threaded -rtsopts -with-rtsopts=-N
     build-depends:
         base >=4.7 && <5,
+        hspec -any,
         tasty -any,
-        tasty-hspec -any,
+        tasty-hspec >= 1.1.7,
         monad-dijkstra -any
 
     if !impl(ghc >=8.0)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,6 +7,7 @@ import           Control.Monad.Search
 
 import           Data.Semigroup       as Sem
 
+import           Test.Hspec
 import           Test.Tasty
 import           Test.Tasty.Hspec
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,7 +7,10 @@ import           Control.Monad.Search
 
 import           Data.Semigroup       as Sem
 
+#if MIN_VERSION_tasty_hspec(1,1,7)
 import           Test.Hspec
+#endif
+
 import           Test.Tasty
 import           Test.Tasty.Hspec
 


### PR DESCRIPTION
tasty-hspec no longer re-exports Test.Hspec since 1.1.7. Let's import
it ourselves.